### PR TITLE
Allow skipping tests for CRAN

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -39,6 +39,8 @@ jobs:
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
       R_KEEP_PKG_SOURCE: yes
+      TORCH_TEST: 1
+      TORCH_INSTALL: 1
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -23,18 +23,12 @@ jobs:
       matrix:
         config:
           - {os: macOS-latest,   r: 'release'}
-
           - {os: windows-latest, r: 'release'}
-          # Use 3.6 to trigger usage of RTools35
-          - {os: windows-latest, r: '3.6'}
 
           # Use older ubuntu to maximise backward compatibility
           - {os: ubuntu-18.04,   r: 'devel', http-user-agent: 'release'}
           - {os: ubuntu-18.04,   r: 'release'}
-          - {os: ubuntu-18.04,   r: 'oldrel-1'}
-          - {os: ubuntu-18.04,   r: 'oldrel-2'}
-          - {os: ubuntu-18.04,   r: 'oldrel-3'}
-          - {os: ubuntu-18.04,   r: 'oldrel-4'}
+
 
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -58,3 +58,5 @@ jobs:
           extra-packages: rcmdcheck
 
       - uses: r-lib/actions/check-r-package@v1
+        with:
+          args: 'c("--no-multiarch", "--no-manual")'

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -14,6 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+      TORCH_INSTALL: 1
     steps:
       - uses: actions/checkout@v2
 

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -13,6 +13,8 @@ jobs:
     runs-on: ubuntu-latest
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+      TORCH_INSTALL: 1
+      TORCH_TEST: 1
 
     steps:
       - uses: actions/checkout@v2

--- a/R/torchopt-package.R
+++ b/R/torchopt-package.R
@@ -11,10 +11,6 @@
 ## usethis namespace: end
 NULL
 
-.onLoad <- function(libname, pkgname) {
-    if (!torch::torch_is_installed())
-        torch::install_torch()
-}
 # Include the following global variables
 utils::globalVariables(c("self", "super", "ctx", "private"))
 

--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -1,3 +1,7 @@
 library(testthat)
 library(torchopt)
-test_check("torchopt")
+
+if (Sys.getenv("TORCH_TEST", unset = 0) == 1) {
+    test_check("torchopt")
+}
+


### PR DESCRIPTION
This PR sets a number of TORCH related environment variables to allow the package to be fully installed on CI and automatically skip tests on CRAN - since CRAN forbids installation of external software in their machines.