### PR TITLE
test_optim: use individual optimizer's defaults

### DIFF
--- a/R/utils-testopt.R
+++ b/R/utils-testopt.R
@@ -210,7 +210,7 @@ test_optim <- function(optim, ...,
     y <- torch::torch_tensor(y0, requires_grad = TRUE)
 
     # instantiate optimizer
-    if(!missing(opt_hparams))
+    if(!is.null(opt_hparams))
         optim <- do.call(optim, c(list(params = list(x, y)), opt_hparams))
     else
         optim <- do.call(optim, c(list(params = list(x, y))))

--- a/R/utils-testopt.R
+++ b/R/utils-testopt.R
@@ -131,8 +131,8 @@ domain_sphere <- function(){
 #'
 #' @param optim          Torch optimizer function.
 #' @param ...            Additional parameters (passed to `image` function).
-#' @param opt_hparams    A list with optimizer initialize parameters
-#'   (default `list(lr = 0.01)`).
+#' @param opt_hparams    A list with optimizer initialization parameters (default: NULL).
+#' If missing, for each optimizer its individual defaults will be used.
 #' @param test_fn        A test function (default `"beale"`). You can also pass
 #'   a list with 2 elements. The first should be a function that will be optimized
 #'   and the second is a function that returns a named vector with `x0`, `y0`
@@ -155,7 +155,7 @@ domain_sphere <- function(){
 #'
 #' @export
 test_optim <- function(optim, ...,
-                       opt_hparams = list(lr = 0.01),
+                       opt_hparams = NULL,
                        test_fn = "beale",
                        steps = 200,
                        pt_start_color = "#5050FF7F",
@@ -210,7 +210,10 @@ test_optim <- function(optim, ...,
     y <- torch::torch_tensor(y0, requires_grad = TRUE)
 
     # instantiate optimizer
-    optim <- do.call(optim, c(list(params = list(x, y)), opt_hparams))
+    if(!missing(opt_hparams))
+        optim <- do.call(optim, c(list(params = list(x, y)), opt_hparams))
+    else
+        optim <- do.call(optim, c(list(params = list(x, y))))
     grad_keep <-  FALSE
     if (!is.null(optim$classname) && optim$classname == c("optim_adahessian")) {
         grad_keep <- TRUE

--- a/R/utils-testopt.R
+++ b/R/utils-testopt.R
@@ -131,7 +131,7 @@ domain_sphere <- function(){
 #'
 #' @param optim          Torch optimizer function.
 #' @param ...            Additional parameters (passed to `image` function).
-#' @param opt_hparams    A list with optimizer initialization parameters (default: NULL).
+#' @param opt_hparams    A list with optimizer initialization parameters (default: `list()`).
 #' If missing, for each optimizer its individual defaults will be used.
 #' @param test_fn        A test function (default `"beale"`). You can also pass
 #'   a list with 2 elements. The first should be a function that will be optimized
@@ -210,10 +210,7 @@ test_optim <- function(optim, ...,
     y <- torch::torch_tensor(y0, requires_grad = TRUE)
 
     # instantiate optimizer
-    if(!is.null(opt_hparams))
-        optim <- do.call(optim, c(list(params = list(x, y)), opt_hparams))
-    else
-        optim <- do.call(optim, c(list(params = list(x, y))))
+    optim <- do.call(optim, c(list(params = list(x, y)), opt_hparams))
     grad_keep <-  FALSE
     if (!is.null(optim$classname) && optim$classname == c("optim_adahessian")) {
         grad_keep <- TRUE

--- a/R/utils-testopt.R
+++ b/R/utils-testopt.R
@@ -155,7 +155,7 @@ domain_sphere <- function(){
 #'
 #' @export
 test_optim <- function(optim, ...,
-                       opt_hparams = NULL,
+                       opt_hparams = list(),
                        test_fn = "beale",
                        steps = 200,
                        pt_start_color = "#5050FF7F",

--- a/man/optim_adahessian.Rd
+++ b/man/optim_adahessian.Rd
@@ -37,44 +37,6 @@ R implementation of the Adahessian optimizer proposed
 by Yao et al.(2020). The original implementation is available at
 https://github.com/amirgholami/adahessian.
 }
-\examples{
-\dontrun{
-
-if (torch::torch_is_installed()) {
-# function to demonstrate optimization
-beale <- function(x, y) {
-    log((1.5 - x + x * y)^2 + (2.25 - x - x * y^2)^2 + (2.625 - x + x * y^3)^2)
- }
-# define optimizer
-optim <- optim_adahessian
-# define hyperparams
-opt_hparams <- list(lr = 0.01)
-
-# starting point
-x0 <- 3
-y0 <- 3
-# create tensor
-x <- torch::torch_tensor(x0, requires_grad = TRUE)
-y <- torch::torch_tensor(y0, requires_grad = TRUE)
-# instantiate optimizer
-optim <- do.call(optim, c(list(params = list(x, y)), opt_hparams))
-# run optimizer
-steps <- 400
-x_steps <- numeric(steps)
-y_steps <- numeric(steps)
-for (i in seq_len(steps)) {
-    x_steps[i] <- as.numeric(x)
-    y_steps[i] <- as.numeric(y)
-    optim$zero_grad()
-    z <- beale(x, y)
-    z$backward(retain_graph = TRUE, create_graph = TRUE)
-    optim$step()
-}
-print(paste0("starting value = ", beale(x0, y0)))
-print(paste0("final value = ", beale(x_steps[steps], y_steps[steps])))
-}
-}
-}
 \references{
 Yao, Z., Gholami, A., Shen, S., Mustafa, M., Keutzer, K.,
 & Mahoney, M. (2021).

--- a/man/test_optim.Rd
+++ b/man/test_optim.Rd
@@ -7,7 +7,7 @@
 test_optim(
   optim,
   ...,
-  opt_hparams = list(lr = 0.01),
+  opt_hparams = NULL,
   test_fn = "beale",
   steps = 200,
   pt_start_color = "#5050FF7F",
@@ -28,8 +28,8 @@ test_optim(
 
 \item{...}{Additional parameters (passed to \code{image} function).}
 
-\item{opt_hparams}{A list with optimizer initialize parameters
-(default \code{list(lr = 0.01)}).}
+\item{opt_hparams}{A list with optimizer initialization parameters (default: NULL).
+If missing, for each optimizer its individual defaults will be used.}
 
 \item{test_fn}{A test function (default \code{"beale"}). You can also pass
 a list with 2 elements. The first should be a function that will be optimized

--- a/man/test_optim.Rd
+++ b/man/test_optim.Rd
@@ -7,7 +7,7 @@
 test_optim(
   optim,
   ...,
-  opt_hparams = NULL,
+  opt_hparams = list(),
   test_fn = "beale",
   steps = 200,
   pt_start_color = "#5050FF7F",
@@ -28,7 +28,7 @@ test_optim(
 
 \item{...}{Additional parameters (passed to \code{image} function).}
 
-\item{opt_hparams}{A list with optimizer initialization parameters (default: NULL).
+\item{opt_hparams}{A list with optimizer initialization parameters (default: \code{list()}).
 If missing, for each optimizer its individual defaults will be used.}
 
 \item{test_fn}{A test function (default \code{"beale"}). You can also pass


### PR DESCRIPTION
Hi,

I think that as a user, if I don't  pass a learning rate via `opt_hparams`, I expect `test_optim()` to instantiate the optimizer with its default learning rate. 
With an optimizer like `optim_adam(),` I probably wouldn't have noticed, but for `optim_adahessian()`, the difference between it's, and the function's, default is enormous.

My code presupposes that every `optim_x()` will have a default learning rate. What do you think @dfalbel, is this reasonable, and if not, do you have a suggestion?